### PR TITLE
Edit html.html.twig template to set appropriate body classes

### DIFF
--- a/nicsdru_unity_theme.theme
+++ b/nicsdru_unity_theme.theme
@@ -76,3 +76,14 @@ function nicsdru_unity_theme_form_user_pass_alter(&$form, FormStateInterface $fo
   $form['#attached']['library'][] = 'nicsdru_unity_theme/nicsdru-authenticated-styles';
 }
 
+/**
+ * Implements hook_preprocess_html().
+ */
+function nicsdru_unity_theme_preprocess_html(&$variables) {
+  $variables['path_info']['args'] = FALSE;
+  $path = \Drupal::request()->getPathInfo();
+  $path_args = explode('/', $path);
+  if (count($path_args) >= 3) {
+    $variables['path_info']['args'] = Html::cleanCssIdentifier(ltrim($path, '/'));
+  }
+}

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -19,6 +19,7 @@
  * - db_offline: A flag indicating if the database is offline.
  * - placeholder_token: The token for generating head, css, js and js-bottom
  *   placeholders.
+ * - path_info.args: The node ID for the current page if the page is a node.
  *
  * @see template_preprocess_html()
  */
@@ -30,9 +31,10 @@
 %}
 {%
   set body_classes = [
-  logged_in ? 'user-logged-in',
-  not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
-  node_type ? 'page-node-type-' ~ node_type|clean_class,
+  logged_in ? 'logged-in',
+  not root_path ? 'front' : 'path-' ~ root_path|clean_class,
+  node_type ? 'node-type-' ~ node_type|clean_class,
+  node_type and path_info.args ? 'node-type-' ~ node_type|clean_class ~ '-' ~ path_info.args|clean_class,
   db_offline ? 'db-offline',
 ]
 %}


### PR DESCRIPTION
Implement hook_preprocess_html to make the node ID available in the html.html.twig template as path_info.args.

I left the links to favicon.html and icons.svg as they are as I'm not sure where these files will be created.