### PR TITLE
Create a component for dash lists

### DIFF
--- a/src/scss/3_components/content/_lists.scss
+++ b/src/scss/3_components/content/_lists.scss
@@ -80,7 +80,9 @@ ul {
 // This is a type of list that divides the list into two columns, with every second list item listed in the right
 // hand column.
 //
-// Markup: ../kss-templates/list-splitlist.twig
+// .split-list - a list divided into two columns.
+//
+// Markup: ../kss-templates/list.twig
 //
 // Style guide: components.content.lists.split-lists
 .split-list {
@@ -101,3 +103,25 @@ ul {
   }
 }
 
+// Dash list
+//
+// This is a type of list that uses a '-' symbol instead of a bullet.
+//
+// .dash-list - A list using a '-' symbol.
+//
+// Markup: ../kss-templates/list.twig
+//
+// Style guide: components.content.lists.dash-lists
+.dash-list {
+  li {
+    position: relative;
+    list-style: none;
+
+    &::before {
+      content: '-';
+      position: absolute;
+      left: -20px;
+      top: 0;
+    }
+  }
+}

--- a/src/scss/3_components/kss-templates/list.twig
+++ b/src/scss/3_components/kss-templates/list.twig
@@ -1,4 +1,4 @@
-<ul class="split-list">
+<ul class="{{ modifier_class }}">
   <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
   <li>Ut etiam sit amet nisl purus in mollis nunc sed.</li>
   <li>Arcu risus quis varius quam quisque.</li>


### PR DESCRIPTION
I have added the dash list documentation in the same way that I wrote the split-list, making use of the twig file written for this. However, I can see that it might be better to document lists in general and just have modifier classes for each of these list classes. 