### PR TITLE
Removing the @import at top of file

### DIFF
--- a/src/scss/3_components/content/_icons-messages.scss
+++ b/src/scss/3_components/content/_icons-messages.scss
@@ -3,7 +3,6 @@
  * Provides the styling for icon components. The file then extrapolates some concepts around icons further
  * for when they are used in some kind of message container.
  */
-@import '../../init/index';
 
 // Icons
 //


### PR DESCRIPTION
Removing the import of the index.scss as it is overriding variables in the uregni_theme.