### PR TITLE
Fixes drupal/coder references to be stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: Fetch phpcs and dependencies
           command: |
-            composer require drupal/coder:^8.3 --no-interaction --optimize-autoloader
+            composer require drupal/coder --prefer-stable --no-interaction --optimize-autoloader
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:


### PR DESCRIPTION
Dependencies were otherwise coming through as dev versions, accounting for the code creep we were seeing in
the CI.

Before:
```
  - Installing symfony/polyfill-ctype (dev-master 1c30264): Cloning 1c302646f6 from cache
  - Installing symfony/deprecation-contracts (dev-master d940483): Cloning d9404839d3 from cache
  - Installing symfony/yaml (dev-master 230b68b): Cloning 230b68b660 from cache
  - Installing squizlabs/php_codesniffer (dev-master 33a4891): Cloning 33a4891b99 from cache
  - Installing drupal/coder (8.3.x-dev d51e0b8): Cloning d51e0b8c65 from cache
```

After:
```
  - Installing symfony/polyfill-ctype (v1.18.1): Downloading (100%)
  - Installing symfony/deprecation-contracts (v2.2.0): Downloading (100%)
  - Installing symfony/yaml (v5.1.7): Downloading (100%)
  - Installing squizlabs/php_codesniffer (3.5.6): Downloading (100%)
  - Installing drupal/coder (8.3.x-dev d51e0b8): Cloning d51e0b8c65 from cache
```