### PR TITLE
allow plugins for code sniffer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
       - run:
           name: Fetch phpcs and dependencies
           command: |
+            composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
             composer require drupal/coder
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../


### PR DESCRIPTION
This was causing all phpcs code checks on the Unity theme to fail